### PR TITLE
Added website documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,22 @@
 # extract_facial
 Extract facial features such as the eyes and mouth from MTCNN's predictions and find whether eyes or mouths are closed/open.
+
 ## Installation
+
 To use, add the extract_facial folder to your Python path. The following dependencies are required: opencv, imutils, and numpy.
-## Functions
-extract_facial has four functions: extractRoi, getEyeOpenClose, getEyeOpenCloseIris, and getMouthOpenClose.
-## extractRoi
-exctractRoi takes in the input image, the results from the MTCNN detector, and a resize factor as its arguments. It outputs a dictionary containing the resized regions of interest (ROI) of the face, left eye, right eye, and mouth, as well as a dictionary containing coordinates to bound all those regions.
-### Syntax
-```python 
-extractedRois, extractedCoords = extract_face.extractRoi(img, detections, resize_factor)
-```
-### Usage
+
+## Basic Usage
+
 ```python
 import cv2
-from mtcnn.mtcnn import MTCNN
 import extract_facial
-
-detector = MTCNN()
 
 img = cv2.imread('person.jpg')
 results = detector.detect_faces(img)
-extractedRois, extractedCoords = extract_facial.extractRoi(img, results, 250)
+extractedRois, extractedCoords = extract_facial.extractRoi(img, 250)
 ```
 
 ## Contributing and Local Development
+
 Please check the [CONTRIBUTING](/CONTRIBUTING.md) guidelines for information 
 on how to contribute to extract_facial.

--- a/website/docs/functions.md
+++ b/website/docs/functions.md
@@ -1,0 +1,17 @@
+# Functions
+
+There are four main functions which `extract_facial` provides which allow you to
+extract facial features from images
+
+### extract_roi
+
+extract_roi takes in the input image from `opencv-python`, and a resize factor as its arguments. 
+It returns the resized regions of interest (ROI) of the face, left eye, right eye, and mouth, as well as 
+coordinates to bound all those regions.
+
+```Python
+import cv2
+from extract_facial import extract_roi
+image = cv2.imread('person.jpg') # you can point to the filepath of any image
+roi, roi_coordinates = extract_roi(image, 250)
+```

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -1,0 +1,17 @@
+# Welcome to MkDocs
+
+For full documentation visit [mkdocs.org](https://www.mkdocs.org).
+
+## Commands
+
+* `mkdocs new [dir-name]` - Create a new project.
+* `mkdocs serve` - Start the live-reloading docs server.
+* `mkdocs build` - Build the documentation site.
+* `mkdocs -h` - Print help message and exit.
+
+## Project layout
+
+    mkdocs.yml    # The configuration file.
+    docs/
+        index.md  # The documentation homepage.
+        ...       # Other markdown pages, images and other files.

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -1,17 +1,11 @@
-# Welcome to MkDocs
+# Getting Started
 
-For full documentation visit [mkdocs.org](https://www.mkdocs.org).
+## Requirements
 
-## Commands
+Python 3.6.1+
 
-* `mkdocs new [dir-name]` - Create a new project.
-* `mkdocs serve` - Start the live-reloading docs server.
-* `mkdocs build` - Build the documentation site.
-* `mkdocs -h` - Print help message and exit.
+## Installation
 
-## Project layout
-
-    mkdocs.yml    # The configuration file.
-    docs/
-        index.md  # The documentation homepage.
-        ...       # Other markdown pages, images and other files.
+```bash
+pip install extract_facial
+```

--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -1,0 +1,1 @@
+site_name: My Docs

--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -1,1 +1,16 @@
-site_name: My Docs
+site_name: Extract Facial
+
+theme:
+  name: material
+
+repo_name: vink246/extract_facial
+repo_url: https://github.com/vink246
+edit_uri: ""
+
+markdown_extensions:
+  - pymdownx.highlight
+  - pymdownx.superfences
+
+nav:
+  - Introduction: 'index.md'
+  - Functions: 'functions.md'


### PR DESCRIPTION
- Using `mkdocs-material` to write documentation for `extract_facial` in markdown
- Finished documentation for function `extract_roi`
- Fixes #5 

This documentation can be deployed anywhere, for example [Firebase Hosting](https://firebase.google.com/products/hosting) or [Github Pages](https://pages.github.com/)

You can take a look at `mkdocs-material` documentation [here](https://squidfunk.github.io/mkdocs-material/)